### PR TITLE
Allow content dimension preset translation

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionController.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Components/ContentDimensionController.js
@@ -158,7 +158,8 @@ function(
 					} else {
 						selected = (presetIdentifier === dimensionConfiguration.defaultPreset);
 					}
-					presets.push(Preset.create($.extend(true, {selected: selected, identifier: presetIdentifier}, presetConfiguration)));
+					var translatedLabel = I18n.translate(presetConfiguration.label);
+					presets.push(Preset.create($.extend(true, {selected: selected, identifier: presetIdentifier}, presetConfiguration, {label: translatedLabel})));
 				});
 
 				if (presets.length > 1) {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
Tranlate content dimension labels.

**How I did it**
Just like it is already done for dimension labels

**How to verify it**
Add content dimension. Enter translation id as label. Add id in your translation. Enjoy!

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
